### PR TITLE
Added Accordion component with basic documentation

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -42,9 +42,9 @@ body {
 
 // NAV
 .main__nav {
-  background: $theme-light-bg;
-  border-right: 1px solid $theme-light-border;
-  color: $theme-light-color;
+  background: $theme-dark-bg;
+  border-right: 1px solid $theme-dark-border;
+  color: $theme-dark-color;
 }
 
 // HEADER

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,7 +19,7 @@ export function hljsLanguages () {
 
 @NgModule({
   declarations: [
-    AppComponent
+    AppComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/app/features/dashboard/dashboard.module.ts
+++ b/src/app/features/dashboard/dashboard.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 
 // Module Routes
- import { DashboardRoutesModule } from './routes/dashboard-routing.module';
+import { DashboardRoutesModule } from './routes/dashboard-routing.module';
 
 // Module Components
 import { DashboardComponent } from './components/dashboard/dashboard.component';

--- a/src/app/features/navigation/components/nav-sidebar-item/nav-sidebar-item.component.html
+++ b/src/app/features/navigation/components/nav-sidebar-item/nav-sidebar-item.component.html
@@ -10,7 +10,7 @@
            (click)="toggleExpand()"></go-icon>
   </div>
   <ul class="nav-menu__sub-nav" *ngIf="menuItem.subRoutes && expanded">
-    <li *ngFor="let item of menuItem.subRoutes">
+    <li class="nav-menu__sub-nav-item" *ngFor="let item of menuItem.subRoutes">
       <a [routerLink]="[item.route]" [routerLinkActive]="['nav-menu__list-item-link--active']" [routerLinkActiveOptions]="{exact:true}" class="nav-menu__list-item-link">
         <span class="nav-menu__sub-nav-title">{{ item.routeTitle }}</span>
       </a>

--- a/src/app/features/navigation/components/nav-sidebar-item/nav-sidebar-item.component.scss
+++ b/src/app/features/navigation/components/nav-sidebar-item/nav-sidebar-item.component.scss
@@ -9,7 +9,7 @@
   @include transition(all);
 
   &:hover {
-    background: $theme-light-bg-hover;
+    background: $theme-dark-bg-hover;
   }
 }
 
@@ -31,15 +31,26 @@
 }
 
 .nav-menu__list-title {
+  font-weight: lighter;
   letter-spacing: 0.02rem;
   padding: 1rem 1rem 1rem 0;
 }
 
 .nav-menu__sub-nav {
   font-size: 0.833rem;
+
+  .nav-menu__sub-nav-item {
+    background: $theme-dark-bg;
+    @include transition(background);
+
+    &:hover {
+      background: $theme-dark-bg-hover;
+    }
+  }
 }
 
 .nav-menu__sub-nav-title {
+  font-weight: lighter;
   letter-spacing: 0.02rem;
   padding: 0.6rem 0.833rem 0.6rem 3.2rem;
 }

--- a/src/app/features/navigation/components/nav-sidebar/nav-sidebar.component.scss
+++ b/src/app/features/navigation/components/nav-sidebar/nav-sidebar.component.scss
@@ -10,7 +10,7 @@
   }
 
   a, a:visited, a:focus, a:active {
-    color: $theme-light-color;
+    color: $theme-dark-color;
   }
 
   a {

--- a/src/app/features/navigation/components/nav-sidebar/nav-sidebar.component.ts
+++ b/src/app/features/navigation/components/nav-sidebar/nav-sidebar.component.ts
@@ -12,6 +12,7 @@ export class NavSidebarComponent implements OnInit {
     { route: '', routeIcon: 'home', routeTitle: 'Home' },
     { route: 'standards', routeIcon: 'power_settings_new', routeTitle: 'Standards' },
     { route: 'ui-kit', routeIcon: 'widgets', routeTitle: 'Components', subRoutes: [
+      { route: 'ui-kit/accordion', routeTitle: 'Accordion' },
       { route: 'ui-kit/table', routeTitle: 'Table'}
     ] },
     { route: 'patterns', routeIcon: 'view_quilt', routeTitle: 'Patterns' },

--- a/src/app/features/ui-kit/components/accordion-docs/accordion-docs.component.html
+++ b/src/app/features/ui-kit/components/accordion-docs/accordion-docs.component.html
@@ -1,0 +1,30 @@
+<h4 class="page-title">{{ pageTitle }}</h4>
+
+<div class="go-container">
+
+  <go-card class="go-column go-column--50">
+    <header go-card-header>
+      <h5>Code</h5>
+    </header>
+    <div go-card-content>
+      <pre><code [highlight]="basicExample" type="xml"></code></pre>
+    </div>
+  </go-card>
+
+  <go-card class="go-column go-column--50">
+    <header go-card-header>
+      <h5>Live Example</h5>
+    </header>
+    <div go-card-content>
+      <go-accordion>
+        <go-accordion-panel title="Test 1" expanded="true">
+          This is some content for <b>Test 1</b>.
+        </go-accordion-panel>
+        <go-accordion-panel title="Test 2">
+          This is a second thing. 
+        </go-accordion-panel>
+      </go-accordion>
+    </div>
+  </go-card>
+
+</div>

--- a/src/app/features/ui-kit/components/accordion-docs/accordion-docs.component.ts
+++ b/src/app/features/ui-kit/components/accordion-docs/accordion-docs.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  templateUrl: './accordion-docs.component.html'
+})
+export class AccordionDocsComponent implements OnInit {
+
+  pageTitle: String;
+
+  basicExample = `
+  <go-accordion>
+    <go-accordion-panel title="Test 1" expanded="true">
+      This is some content for <b>Test 1</b>.
+    </go-accordion-panel>
+    <go-accordion-panel title="Test 2">
+      This is a second thing. 
+    </go-accordion-panel>
+  </go-accordion>
+  `
+
+  ngOnInit() {
+    this.pageTitle = "Accordion";
+  }
+
+}

--- a/src/app/features/ui-kit/routes/ui-kit-routing.module.ts
+++ b/src/app/features/ui-kit/routes/ui-kit-routing.module.ts
@@ -1,11 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { AccordionDocsComponent } from '../components/accordion-docs/accordion-docs.component';
 import { TableDocsComponent } from '../components/table-docs/table-docs.component';
 import { UiKitComponent } from '../components/ui-kit/ui-kit.component';
 
 const routes: Routes = [
   { path: 'ui-kit', component: UiKitComponent },
+  { path: 'ui-kit/accordion', component: AccordionDocsComponent },
   { path: 'ui-kit/table', component: TableDocsComponent }
 ];
 

--- a/src/app/features/ui-kit/ui-kit.module.ts
+++ b/src/app/features/ui-kit/ui-kit.module.ts
@@ -1,17 +1,23 @@
 import { NgModule } from '@angular/core';
+import { SharedModule } from 'src/app/shared/shared.module';
+import { HighlightModule } from 'ngx-highlightjs';
 
 // Module Routes
 import { UiKitRoutesModule } from './routes/ui-kit-routing.module';
 
 // Module Components
+import { AccordionDocsComponent } from './components/accordion-docs/accordion-docs.component';
 import { TableDocsComponent } from './components/table-docs/table-docs.component';
 import { UiKitComponent } from './components/ui-kit/ui-kit.component'
 
 @NgModule({
   imports: [
+    HighlightModule,
+    SharedModule,
     UiKitRoutesModule
   ],
   declarations: [
+    AccordionDocsComponent,
     TableDocsComponent,
     UiKitComponent
   ]

--- a/src/app/shared/components/go-accordion/go-accordion-panel.component.html
+++ b/src/app/shared/components/go-accordion/go-accordion-panel.component.html
@@ -1,0 +1,19 @@
+<div class="go-accordion-panel" [ngClass]="{ 'go-accordion-panel--active': expanded, 'go-accordion-panel--inactive': !expanded }">
+  <header class="go-accordion-panel__title-bar" (click)="toggle.emit()" aria-expanded="expanded">
+    <span class="go-accordion-panel__title">
+      <span *ngIf="icon" class="material-icons go-accordion-panel__title-icon">{{ icon }}</span>
+      <span class="go-accordion-panel__title-text" [innerHtml]="title"></span>
+      <!-- <span class='clipboard' ng-if="$ctrl.copyText">
+        <button type='button' class='copy-to-clipboard icon-button' data-clipboard-text='{{$ctrl.copyText}}'></button>
+      </span> -->
+    </span>
+    <span class="go-accordion-panel__control">
+      <span class="material-icons go-accordion-panel__control-icon">expand_more</span>
+    </span>
+  </header>
+  <div class="go-accordion-panel__content-container">
+    <div class="go-accordion-panel__content">
+      <ng-content></ng-content>
+    </div>
+  </div>
+</div>

--- a/src/app/shared/components/go-accordion/go-accordion-panel.component.scss
+++ b/src/app/shared/components/go-accordion/go-accordion-panel.component.scss
@@ -1,0 +1,206 @@
+@import 'variables';
+@import 'mixins';
+
+.go-accordion-panel__title-bar {
+  cursor: pointer;
+  display: flex;
+  font-size: 1.2rem;
+  padding: 1.2rem 0;
+  position: relative;
+  @include transition(all);
+}
+
+.go-accordion-panel__title {
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+}
+
+.go-accordion-panel__title-icon {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: 1rem;
+  text-align: center;
+}
+
+.go-accordion-panel__title-text {
+  padding-left: 1rem;
+}
+
+.go-accordion-panel__control {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0 1rem;
+  text-align: center;
+}
+
+.go-accordion-panel__control-icon {
+  @include transition(all);
+}
+
+.go-accordion-panel__content-container {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  visibility: hidden;
+  @include transition(max-height opacity);
+}
+
+.go-accordion-panel__content {
+  display: block;
+  padding: 0 1rem;
+  @include transition(all);
+}
+
+// ----- Light Theme Classes
+.go-accordion--theme-light {
+  background: $theme-light-bg;
+  border: 1px solid $theme-light-border;
+  color: $theme-light-color;
+
+  go-accordion-panel:not(:first-of-type) .go-accordion-panel__title-bar,
+  go-accordion-panel:last-of-type .go-accordion-panel__title-bar {
+    border-top: 1px solid $theme-light-border;
+  }
+
+  .go-accordion-panel--border-top .go-accordion-panel__title-bar {
+    border-top: 1px solid $theme-light-border;
+  }
+
+  .go-accordion-panel--active .go-accordion-panel__title-bar {
+    background: $theme-light-bg-active;
+  }
+
+  .go-accordion-panel--inactive .go-accordion-panel__title-bar {
+    background: $theme-light-bg;
+  }
+
+  .go-accordion-panel__title-bar:hover {
+    background: $theme-light-bg-hover;
+  }
+
+  .go-accordion-panel__content {
+    color: $theme-light-color;
+  }
+}
+
+// ----- Dark Theme Classes
+.go-accordion--theme-dark {
+  background: $theme-dark-bg;
+  border: 1px solid $theme-dark-border;
+  color: $theme-dark-color;
+  font-weight: 300;
+
+  go-accordion-panel:not(:first-of-type) .go-accordion-panel__title-bar,
+  go-accordion-panel:last-of-type .go-accordion-panel__title-bar {
+    border-top: 1px solid $theme-dark-border;
+  }
+
+  .go-accordion-panel--border-top .go-accordion-panel__title-bar {
+    border-top: 1px solid $theme-dark-border;
+  }
+
+  .go-accordion-panel--active .go-accordion-panel__title-bar {
+    background: $theme-dark-bg-active;
+  }
+
+  .go-accordion-panel--inactive .go-accordion-panel__title-bar {
+    background: $theme-dark-bg;
+  }
+
+  .go-accordion-panel__title-bar:hover {
+    background: $theme-dark-bg-hover;
+  }
+
+  .go-accordion-panel__content {
+    color: $theme-dark-color;
+    font-weight: 300;
+  }
+}
+
+go-accordion-panel {
+  &:last-of-type {
+    .go-accordion-panel::before {
+      border-bottom-left-radius: calc(#{$global-radius} - 1px);
+    }
+
+    .go-accordion-panel__title-bar {
+      border-radius: 0 0 $global-radius $global-radius;
+      overflow: hidden;
+    }
+  }
+
+  &:first-of-type {
+    .go-accordion-panel::before {
+      border-top-left-radius: calc(#{$global-radius} - 1px);
+    }
+
+    .go-accordion-panel__title-bar {
+      border-radius: $global-radius $global-radius 0 0 ;
+      overflow: hidden;
+    }
+  }
+}
+
+.go-accordion-panel {
+  position: relative;
+
+  &::before {
+    background: $gradient-primary-horizontal;
+    background-color: $base-primary;
+    content: " ";
+    height: 100%;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    transition: all 0.25s ease-in;
+    width: 4px;
+    z-index: 1;
+  }
+
+  &.go-accordion-panel--active {
+
+    &::before {
+      opacity: 1;
+    }
+
+    .go-accordion-panel__control .material-icons {
+      transform: rotate(180deg);
+    }
+
+    .go-accordion-panel__content-container {
+      max-height: 1000000px; // this is arbitrary, used for animation
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .go-accordion-panel__content {
+      padding: 1.5rem 1rem;
+    }
+  }
+
+  &.go-accordion-panel--inactive {
+    &::before {
+      opacity: 0;
+    }
+
+    .go-accordion-panel__control .material-icons {
+      transform: rotate(0deg);
+    }
+
+    .go-accordion-panel__content-container {
+      max-height: 0;
+      opacity: 0;
+      visibility: hidden;
+    }
+  }
+}
+
+// ----- Utility Classes
+.go-accordion--slim {
+  .go-accordion-panel__title-bar {
+    font-size: 1rem;
+  }
+}

--- a/src/app/shared/components/go-accordion/go-accordion-panel.component.spec.ts
+++ b/src/app/shared/components/go-accordion/go-accordion-panel.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GoAccordionPanelComponent } from './go-accordion-panel.component';
+
+describe('GoAccordionPanelComponent', () => {
+  let component: GoAccordionPanelComponent;
+  let fixture: ComponentFixture<GoAccordionPanelComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GoAccordionPanelComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GoAccordionPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/go-accordion/go-accordion-panel.component.ts
+++ b/src/app/shared/components/go-accordion/go-accordion-panel.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit, Input, Output, EventEmitter, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'go-accordion-panel',
+  templateUrl: './go-accordion-panel.component.html',
+  styleUrls: ['./go-accordion-panel.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class GoAccordionPanelComponent implements OnInit {
+
+  @Input() expanded: boolean;
+  @Input() icon: string;
+  @Input() title: string;
+  
+  @Output() toggle: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor() { }
+
+  ngOnInit() {
+    this.expanded = this.expanded || false;
+  }
+
+}

--- a/src/app/shared/components/go-accordion/go-accordion.component.html
+++ b/src/app/shared/components/go-accordion/go-accordion.component.html
@@ -1,0 +1,3 @@
+<div class="go-accordion" [ngClass]="[activeTheme]">
+  <ng-content></ng-content>
+</div>

--- a/src/app/shared/components/go-accordion/go-accordion.component.scss
+++ b/src/app/shared/components/go-accordion/go-accordion.component.scss
@@ -1,0 +1,14 @@
+@import 'variables';
+
+.go-accordion {
+  border-radius: $global-radius;
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+}
+
+.go-accordion--theme-light {
+  background: $theme-light-bg;
+  border: 1px solid $theme-light-border;
+  color: $theme-light-color;
+}

--- a/src/app/shared/components/go-accordion/go-accordion.component.spec.ts
+++ b/src/app/shared/components/go-accordion/go-accordion.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GoAccordionComponent } from './go-accordion.component';
+
+describe('AccordionComponent', () => {
+  let component: GoAccordionComponent;
+  let fixture: ComponentFixture<GoAccordionComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GoAccordionComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GoAccordionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/go-accordion/go-accordion.component.ts
+++ b/src/app/shared/components/go-accordion/go-accordion.component.ts
@@ -1,0 +1,64 @@
+import { Component, OnInit, AfterContentInit, Input, QueryList, ContentChildren } from '@angular/core';
+import { GoAccordionPanelComponent } from './go-accordion-panel.component';
+
+@Component({
+  selector: 'go-accordion',
+  templateUrl: './go-accordion.component.html',
+  styleUrls: ['./go-accordion.component.scss']
+})
+export class GoAccordionComponent implements OnInit, AfterContentInit {
+
+  @Input() expandAll: boolean = false;
+  @Input() multiExpand: boolean = false;
+  @Input() showIcons: boolean = false;
+  @Input() theme: string = 'light';
+
+  activeTheme: string;
+
+  @ContentChildren(GoAccordionPanelComponent) panels: QueryList<GoAccordionPanelComponent>;
+
+  constructor() { }
+
+  ngOnInit() {
+    this.setActiveTheme();
+    this.multiExpand = this.expandAll || this.multiExpand;
+  }
+
+  ngAfterContentInit() {
+    this.panels.toArray().forEach((p) => {
+      p.toggle.subscribe(() => {
+        if (!p.expanded && this.multiExpand) {
+          this.openPanel(p);
+        } else if (!p.expanded && !this.multiExpand) {
+          this.openPanelCloseOthers(p);
+        } else {
+          this.closePanel(p);
+        }
+      });
+
+      p.expanded = this.expandAll || p.expanded;
+      p.icon = !this.showIcons ? null : p.icon;
+    })
+  }
+
+  openPanelCloseOthers(panel: GoAccordionPanelComponent) {
+    this.panels.toArray().forEach((p) => {
+      this.closePanel(p);
+    });
+
+    this.openPanel(panel);
+  }
+
+  openPanel(panel: GoAccordionPanelComponent) {
+    panel.expanded = true;
+  }
+
+  closePanel(panel: GoAccordionPanelComponent) {
+    panel.expanded = false;
+  }
+  
+  setActiveTheme() {
+    this.activeTheme = 'go-accordion--theme-' + this.theme;
+  }
+
+}

--- a/src/app/shared/components/icon/icon.component.scss
+++ b/src/app/shared/components/icon/icon.component.scss
@@ -8,13 +8,13 @@
 
 .nav-menu__list-expand-icon {
   border-radius: 50%;
-  color: $theme-light-color;
+  color: $theme-dark-color;
   cursor: pointer;
   padding: 0.5rem;
   @include transition(all);
 
   &:hover {
-    background: darken($theme-light-bg-hover, 10%);
+    background: $theme-dark-bg;
   }
 }
 

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -3,15 +3,21 @@ import { CommonModule } from '@angular/common';
 
 import { CardComponent } from './components/card/card.component';
 import { IconComponent } from './components/icon/icon.component';
+import { GoAccordionComponent } from './components/go-accordion/go-accordion.component';
+import { GoAccordionPanelComponent } from './components/go-accordion/go-accordion-panel.component';
 
 @NgModule({
   declarations: [
     CardComponent,
-    IconComponent
+    IconComponent,
+    GoAccordionComponent,
+    GoAccordionPanelComponent
   ],
   exports: [
     CardComponent,
-    IconComponent
+    IconComponent,
+    GoAccordionComponent,
+    GoAccordionPanelComponent
   ],
   imports: [
     CommonModule

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -78,3 +78,7 @@ caption {
   letter-spacing: 1.5pt;
   text-transform: uppercase;
 }
+
+.page-title {
+  padding: 0 1rem 1rem 1rem;
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -14,7 +14,9 @@ $base-dark: #313536;
 $base-dark-secondary: #202626;
 $base-light: #fff;
 $base-light-secondary: #b1b1b1;
-$base-primary: #93989d;
+// $base-primary: #93989d;
+$base-primary: #65B360;
+$gradient-primary-horizontal: linear-gradient(to right, $base-primary, darken($base-primary, 7%));
 
 // Light Theme
 $theme-light-app-bg: #F0F0F0;


### PR DESCRIPTION
Simple usage:
```
<go-accordion>
  <go-accordion-panel title="Test 1" expanded="true">
    This is some content for <b>Test 1</b>.
  </go-accordion-panel>
  <go-accordion-panel title="Test 2">
    This is a second thing. 
  </go-accordion-panel>
</go-accordion>
```